### PR TITLE
Support rotating glyphs with components.

### DIFF
--- a/Extensions/GlyphRotator.roboFontExt/info.plist
+++ b/Extensions/GlyphRotator.roboFontExt/info.plist
@@ -30,9 +30,9 @@
 	<key>requiresVersionMinor</key>
 	<string>5</string>
 	<key>timeStamp</key>
-	<real>1424194713.0</real>
+	<real>1459989900.47</real>
 	<key>version</key>
-	<string>1.3</string>
+	<string>1.4</string>
 	<key>com.robofontmechanic.Mechanic</key>
 	<dict>
 		<key>repository</key>


### PR DESCRIPTION
Version 1.3 freezes Robofont whenever it hits a component glyph. This fix solves that problem.
(Accomplished by lifting the `_deepAppendGlyph` function from @miguelsousa’s “Adjust Anchors” Extension.) 